### PR TITLE
Bug fix for getting request return

### DIFF
--- a/client.js
+++ b/client.js
@@ -14,7 +14,7 @@ Client.prototype.poke = function(item, data, timeout) {
 
 Client.prototype.request = function(item, format, timeout) {
   this.item = item;
-  Clients.prototype.request.call(this, format, timeout);
+  return Clients.prototype.request.call(this, format, timeout);
 };
 
 Client.prototype.startAdvise = function(item, format, hot, timeout) {


### PR DESCRIPTION
I have found that the function ```client.request()``` return nothing, but ```clients.request()``` works fine.
I just added ```return``` to fix it.