### PR TITLE
Support for Edge 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ server.register();
 
 // Client
 
-client = dde.createClient(service, topic, encoding)
+client = dde.createClient(service, topic)
 client.connect()
 client.disconnect()
 client.pause()
@@ -143,7 +143,7 @@ client.isPaused()
 
 // Clients
 
-clients = dde.createClients(services, encoding)
+clients = dde.createClients(services)
 clients.connect()
 clients.disconnect()
 clients.pause()
@@ -224,10 +224,6 @@ server.onPoke = function(service, topic, item, data, format) {};
 server.onRequest = function(service, topic, item, format) { return ''; };
 server.onAdvise = function(topic, item, format) { return ''; };
 ```
-
-# Multi-byte string support
-
-To specify a service / topic / item names that contain multi-byte charactors, you can pass a URL-encoded string as an argument to client methods. Decoding will be done when an [encoding name](http://msdn.microsoft.com/en-us/library/vstudio/System.Text.Encoding.aspx) is passed to `createClient` or `createClients` functions.
 
 # License
 

--- a/client.js
+++ b/client.js
@@ -1,10 +1,10 @@
 var Clients = require('./clients.js').Clients;
 
-function Client(service, topic, encoding) {
+function Client(service, topic) {
   var services = {};
   services[service] = {};
   services[service][topic] = null;
-  Clients.call(this, services, encoding);
+  Clients.call(this, services);
 }
 
 Client.prototype.poke = function(item, data, timeout) {
@@ -69,6 +69,6 @@ Client.prototype.beginStopAdvise = function(item, oncomplete) {
 
 Client.prototype.__proto__ = Clients.prototype;
 
-exports.createClient = function(service, topic, encoding) {
-  return new Client(service, topic, encoding);
+exports.createClient = function(service, topic) {
+  return new Client(service, topic);
 };

--- a/clients.js
+++ b/clients.js
@@ -2,12 +2,12 @@ var edge = require('edge');
 
 var getInvoker = edge.func({
   source: __dirname + '/client.cs',
-  references: [ __dirname + '/vendor/NDde.dll', 'System.Web.dll' ],
+  references: [ __dirname + '/vendor/NDde.dll' ],
   typeName: 'NodeDde.Client',
   methodName: 'GetInvoker'
 });
 
-function Clients(services, encoding) {
+function Clients(services) {
   var self = this;
   var opts = {
     services: services,
@@ -20,7 +20,6 @@ function Clients(services, encoding) {
       }
     }
   }
-  if (encoding) opts.encoding = encoding;
   this._invoke = getInvoker(opts, true);
   this.command = this.data = '';
   this.format = 1;
@@ -130,6 +129,6 @@ Clients.prototype.__proto__ = require('events').EventEmitter.prototype;
 
 exports.Clients = Clients;
 
-exports.createClients = function(services, encoding) {
-  return new Clients(services, encoding);
+exports.createClients = function(services) {
+  return new Clients(services);
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "thunder9",
     "url": "https://github.com/thunder9"
   },
-  "version": "0.0.1",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/thunder9/node-dde.git"
@@ -12,7 +12,7 @@
   "os": [ "win32" ],
   "license": "MIT",
   "dependencies": {
-    "edge": "*"
+    "edge": "~0.10.1"
   },
   "devDependencies": {
     "timelineplayer": "git://github.com/thunder9/timelineplayer.js.git"

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -53,7 +53,7 @@ var id = setInterval(function() { console.log('v8 thread-' + i++)}, 1000);
   clients = dde.createClients({
     myapp: {
       mytopic1: ['myitem1', 'myitem2'],
-      mytopic2: ['myitem1', '%82%DC%82%A2%82%A0%82%A2%82%C4%82%DE%82Q']
+      mytopic2: ['myitem1', 'まいあいてむ２']
     }
   }, 'shift_jis');
   console.log(clients.service());


### PR DESCRIPTION
ref #5 

- Remove no longer needed `encoding` argument since the problem of marshalling of unicode characters has been fixed in Edge.